### PR TITLE
chore: pin and validate OpenClaw updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ Thumbs.db
 
 # Test results (generated, not shipped)
 tests/results/
+.validation/
+.fallow/
 
 # Local dev config
 CLAUDE.md

--- a/.openclaw-version.json
+++ b/.openclaw-version.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026.4.29",
+  "version": "2026.5.3-1",
   "channel": "stable",
-  "promotedAt": "2026-05-03",
-  "validatedBy": "manual",
-  "notes": "Initial pin replacing openclaw@latest. Future updates must pass local Docker and Railway staging validation before promotion."
+  "promotedAt": "2026-05-05",
+  "validatedBy": "local-docker+railway-staging",
+  "notes": "Promoted after local Docker and Railway staging validation. Previous version: 2026.4.29."
 }

--- a/.openclaw-version.json
+++ b/.openclaw-version.json
@@ -1,0 +1,7 @@
+{
+  "version": "2026.4.29",
+  "channel": "stable",
+  "promotedAt": "2026-05-03",
+  "validatedBy": "manual",
+  "notes": "Initial pin replacing openclaw@latest. Future updates must pass local Docker and Railway staging validation before promotion."
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM node:22-bookworm
 
-ARG OPENCLAW_VERSION=2026.4.29
+ARG OPENCLAW_VERSION=2026.5.3-1
 
 # Install minimal runtime dependencies
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@
 
 FROM node:22-bookworm
 
+ARG OPENCLAW_VERSION=2026.4.29
+
 # Install minimal runtime dependencies
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -14,8 +16,12 @@ RUN apt-get update \
     procps \
   && rm -rf /var/lib/apt/lists/*
 
-# Install OpenClaw globally (always latest — busts cache via Railway redeploy)
-RUN npm install -g openclaw@latest
+# Install the pinned OpenClaw runtime. Version bumps must go through the
+# validation pipeline. Bun global installs currently place the binary outside
+# this image's runtime PATH and block OpenClaw postinstalls, so the runtime
+# package install stays on npm until OpenClaw supports Bun global installs here.
+RUN npm install -g "openclaw@${OPENCLAW_VERSION}" \
+  && openclaw --version
 
 # Create non-root user
 RUN groupadd -g 1001 openclaw \

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -16,7 +16,9 @@
   },
   "channels": {
     "telegram": {
-      "streaming": "off"
+      "streaming": {
+        "mode": "off"
+      }
     }
   },
   "messages": {

--- a/docs/UPSTREAM-UPDATES.md
+++ b/docs/UPSTREAM-UPDATES.md
@@ -1,0 +1,86 @@
+# OpenClaw Upstream Updates
+
+This template pins OpenClaw. Redeploying the Railway service must not silently
+install a newly published upstream runtime.
+
+## Policy
+
+- `main` contains only a version that has already passed validation.
+- New upstream releases are candidates, not deployments.
+- Beta/prerelease versions can be tested in staging, but should not be promoted
+  for public template users without an explicit override decision.
+- Any failed gate blocks promotion.
+- Any unknown warning blocks promotion until classified.
+- Any config, permission, plugin, channel, or secret-handling change in upstream
+  release notes requires manual review before promotion.
+
+## Local Docker Validation
+
+```bash
+bun run openclaw:validate:local -- 2026.5.2-beta.2
+```
+
+The local gate checks:
+
+- package exists on npm
+- Docker image builds with `OPENCLAW_VERSION`
+- installed `openclaw --version` matches the candidate
+- container boots
+- `/healthz` passes
+- generated config exists at `root:openclaw 640`
+- Tier 0 keeps exec allowlist and `workspaceOnly`
+- logs do not contain known blocker patterns
+
+Artifacts are written under `.validation/openclaw/<version>/<run-id>/`.
+
+## Railway Staging Validation
+
+Use the `openclaw-railway` Railway project with a dedicated staging
+environment/service, never the production service.
+
+```bash
+RAILWAY_ENVIRONMENT=staging \
+OPENCLAW_RAILWAY_STAGING_CONFIRMED=1 \
+OPENCLAW_STAGING_HEALTH_URL=https://your-staging-service.up.railway.app \
+bun run openclaw:validate:railway -- 2026.5.2-beta.2
+```
+
+The staging gate requires a passing local validation artifact first. It deploys
+the candidate from a temporary deploy bundle with that candidate baked into the
+Dockerfile, checks health when a staging URL is provided, captures Railway logs,
+and blocks on known failure patterns. Set `OPENCLAW_RAILWAY_STAGING_SERVICE` if
+your linked Railway service is not the staging service.
+
+Before promotion, also run a live channel smoke test with staging credentials:
+
+- send a message to the staging bot
+- confirm a real response
+- confirm deploy/runtime logs do not expose secrets
+- restart or redeploy once and confirm the gateway returns healthy
+
+## Promotion
+
+Promotion is blocked until both local and Railway validation artifacts exist and
+are passing:
+
+```bash
+bun run openclaw:promote -- 2026.5.2-beta.2
+```
+
+That updates:
+
+- `Dockerfile`
+- `.openclaw-version.json`
+
+Open a PR with links or pasted excerpts from the validation reports. Merge only
+after reviewing the evidence and confirming rollback.
+
+## Rollback
+
+Rollback is a normal version-pin revert:
+
+1. Set `ARG OPENCLAW_VERSION` back to the previous known-good version.
+2. Set `.openclaw-version.json.version` back to the same version.
+3. Redeploy.
+
+Never run `openclaw update` inside the container.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -814,7 +814,7 @@ if [ -f "$CONFIG_FILE" ]; then
   (
     sleep 30  # Grace period for gateway to fully boot
     while true; do
-      if ! pidof openclaw-gateway >/dev/null 2>&1; then
+      if ! pgrep -f "openclaw gateway run|openclaw-gateway" >/dev/null 2>&1; then
         echo "[entrypoint] Watchdog: gateway process gone — exiting container so Railway respawns"
         kill -TERM 1 2>/dev/null
         sleep 5

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "type": "module",
   "main": "src/server.js",
   "scripts": {
-    "start": "node src/server.js"
+    "start": "node src/server.js",
+    "openclaw:validate:local": "bash scripts/validate-openclaw-local.sh",
+    "openclaw:validate:railway": "bash scripts/validate-openclaw-railway.sh",
+    "openclaw:promote": "bash scripts/promote-openclaw-version.sh"
   }
 }

--- a/scripts/promote-openclaw-version.sh
+++ b/scripts/promote-openclaw-version.sh
@@ -36,12 +36,20 @@ CURRENT="$(node -e "const fs=require('fs'); console.log(JSON.parse(fs.readFileSy
 
 node - "$VERSION" <<'NODE'
 const fs = require('fs');
+const { execFileSync } = require('child_process');
 const version = process.argv[2];
 const path = '.openclaw-version.json';
 const data = JSON.parse(fs.readFileSync(path, 'utf8'));
 const previous = data.version;
+let latest = '';
+try {
+  const raw = execFileSync('bun', ['pm', 'view', 'openclaw', 'dist-tags', '--json'], { encoding: 'utf8' });
+  latest = JSON.parse(raw).latest || '';
+} catch {
+  latest = '';
+}
 data.version = version;
-data.channel = version.includes('-') ? 'prerelease' : 'stable';
+data.channel = version === latest || !version.includes('-') ? 'stable' : 'prerelease';
 data.promotedAt = new Date().toISOString().slice(0, 10);
 data.validatedBy = 'local-docker+railway-staging';
 data.notes = `Promoted after local Docker and Railway staging validation. Previous version: ${previous}.`;

--- a/scripts/promote-openclaw-version.sh
+++ b/scripts/promote-openclaw-version.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: bun run openclaw:promote -- <openclaw-version>"
+  exit 2
+fi
+
+SAFE_VERSION="$(printf '%s' "$VERSION" | tr -c 'A-Za-z0-9._-' '_')"
+LOCAL_SUMMARY="$(find ".validation/openclaw/${SAFE_VERSION}" -path '*/summary.json' -not -path '*-railway/*' -print 2>/dev/null | sort | tail -1 || true)"
+RAILWAY_SUMMARY="$(find ".validation/openclaw/${SAFE_VERSION}" -path '*-railway/summary.json' -print 2>/dev/null | sort | tail -1 || true)"
+
+if [[ -z "$LOCAL_SUMMARY" || -z "$RAILWAY_SUMMARY" ]]; then
+  echo "ERROR: promotion requires passing local and Railway staging validation artifacts."
+  echo "Local summary:   ${LOCAL_SUMMARY:-missing}"
+  echo "Railway summary: ${RAILWAY_SUMMARY:-missing}"
+  exit 1
+fi
+
+node - "$LOCAL_SUMMARY" "$RAILWAY_SUMMARY" <<'NODE'
+const fs = require('fs');
+for (const path of process.argv.slice(2)) {
+  const summary = JSON.parse(fs.readFileSync(path, 'utf8'));
+  if (summary.status !== 'pass') {
+    console.error(`ERROR: validation summary is not passing: ${path}`);
+    process.exit(1);
+  }
+}
+NODE
+
+CURRENT="$(node -e "const fs=require('fs'); console.log(JSON.parse(fs.readFileSync('.openclaw-version.json','utf8')).version)")"
+
+node - "$VERSION" <<'NODE'
+const fs = require('fs');
+const version = process.argv[2];
+const path = '.openclaw-version.json';
+const data = JSON.parse(fs.readFileSync(path, 'utf8'));
+const previous = data.version;
+data.version = version;
+data.channel = version.includes('-') ? 'prerelease' : 'stable';
+data.promotedAt = new Date().toISOString().slice(0, 10);
+data.validatedBy = 'local-docker+railway-staging';
+data.notes = `Promoted after local Docker and Railway staging validation. Previous version: ${previous}.`;
+fs.writeFileSync(path, JSON.stringify(data, null, 2) + '\n');
+NODE
+
+node - "$VERSION" <<'NODE'
+const fs = require('fs');
+const version = process.argv[2];
+const path = 'Dockerfile';
+let text = fs.readFileSync(path, 'utf8');
+text = text.replace(/^ARG OPENCLAW_VERSION=.*$/m, `ARG OPENCLAW_VERSION=${version}`);
+fs.writeFileSync(path, text);
+NODE
+
+cat <<EOF
+Promoted OpenClaw ${CURRENT} -> ${VERSION}
+
+Updated:
+- Dockerfile
+- .openclaw-version.json
+
+Evidence:
+- ${LOCAL_SUMMARY}
+- ${RAILWAY_SUMMARY}
+EOF

--- a/scripts/validate-openclaw-local.sh
+++ b/scripts/validate-openclaw-local.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: bun run openclaw:validate:local -- <openclaw-version>"
+  exit 2
+fi
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $1"
+    exit 1
+  fi
+}
+
+require_cmd bun
+require_cmd docker
+require_cmd node
+
+RUN_ID="$(date -u '+%Y%m%dT%H%M%SZ')"
+SAFE_VERSION="$(printf '%s' "$VERSION" | tr -c 'A-Za-z0-9._-' '_')"
+ARTIFACT_DIR=".validation/openclaw/${SAFE_VERSION}/${RUN_ID}"
+IMAGE_TAG="openclaw-railway:validate-${SAFE_VERSION}"
+CONTAINER_NAME="openclaw-railway-validate-${SAFE_VERSION}-${RUN_ID}"
+LOG_FILE="${ARTIFACT_DIR}/container.log"
+SUMMARY_JSON="${ARTIFACT_DIR}/summary.json"
+REPORT_MD="${ARTIFACT_DIR}/report.md"
+
+mkdir -p "$ARTIFACT_DIR"
+
+finish() {
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+trap finish EXIT
+
+write_summary() {
+  local status="$1"
+  local reason="$2"
+  node - "$SUMMARY_JSON" "$VERSION" "$status" "$reason" "$RUN_ID" <<'NODE'
+const fs = require('fs');
+const [path, version, status, reason, runId] = process.argv.slice(2);
+fs.writeFileSync(path, JSON.stringify({
+  target: 'local-docker',
+  version,
+  status,
+  reason,
+  runId,
+  generatedAt: new Date().toISOString(),
+}, null, 2) + '\n');
+NODE
+}
+
+capture_container_artifacts() {
+  if docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+    docker logs "$CONTAINER_NAME" >"$LOG_FILE" 2>&1 || true
+    mkdir -p "${ARTIFACT_DIR}/stability"
+    docker cp "${CONTAINER_NAME}:/data/.openclaw/logs/stability/." "${ARTIFACT_DIR}/stability/" >/dev/null 2>&1 || true
+    docker cp "${CONTAINER_NAME}:/data/.openclaw/openclaw.json" "${ARTIFACT_DIR}/openclaw.json" >/dev/null 2>&1 || true
+  fi
+}
+
+fail() {
+  local reason="$1"
+  capture_container_artifacts
+  write_summary "fail" "$reason"
+  {
+    echo "# OpenClaw Local Validation: ${VERSION}"
+    echo
+    echo "Status: FAIL"
+    echo "Reason: ${reason}"
+    echo
+    echo "Artifacts:"
+    echo "- ${LOG_FILE}"
+    echo "- ${SUMMARY_JSON}"
+    echo "- ${ARTIFACT_DIR}/stability/"
+  } > "$REPORT_MD"
+  echo "FAIL: $reason"
+  echo "Report: $REPORT_MD"
+  exit 1
+}
+
+echo "[validate-local] Checking npm package exists: openclaw@${VERSION}"
+VERSIONS_JSON="$(bun pm view openclaw versions --json)"
+node - "$VERSION" "$VERSIONS_JSON" <<'NODE' || fail "openclaw@${VERSION} does not exist on npm"
+const [version, raw] = process.argv.slice(2);
+const versions = JSON.parse(raw);
+if (!versions.includes(version)) process.exit(1);
+NODE
+
+echo "[validate-local] Building Docker image with OPENCLAW_VERSION=${VERSION}"
+docker build \
+  --build-arg "OPENCLAW_VERSION=${VERSION}" \
+  -t "$IMAGE_TAG" \
+  . >"${ARTIFACT_DIR}/docker-build.log" 2>&1 || fail "docker build failed"
+
+echo "[validate-local] Verifying installed OpenClaw version"
+INSTALLED_VERSION="$(docker run --rm --entrypoint openclaw "$IMAGE_TAG" --version 2>/dev/null | tr -d '\r' | tail -1 || true)"
+if [[ "$INSTALLED_VERSION" != *"$VERSION"* ]]; then
+  echo "$INSTALLED_VERSION" > "${ARTIFACT_DIR}/installed-version.txt"
+  fail "installed version did not match candidate"
+fi
+
+echo "[validate-local] Booting container"
+docker run -d \
+  --name "$CONTAINER_NAME" \
+  -p 0:8080 \
+  -e PORT=8080 \
+  -e OPENROUTER_API_KEY="validation-openrouter-key" \
+  -e LLM_PRIMARY_MODEL="openrouter/openai/gpt-4o-mini" \
+  -e SECURITY_TIER="0" \
+  "$IMAGE_TAG" >/dev/null || fail "container failed to start"
+
+HEALTH_URL=""
+for _ in $(seq 1 45); do
+  docker logs "$CONTAINER_NAME" >"$LOG_FILE" 2>&1 || true
+  HOST_PORT="$(docker port "$CONTAINER_NAME" 8080/tcp 2>/dev/null | sed 's/.*://g' | head -1 || true)"
+  if [[ -n "$HOST_PORT" ]]; then
+    HEALTH_URL="http://127.0.0.1:${HOST_PORT}/healthz"
+    if docker exec "$CONTAINER_NAME" curl -sf "http://localhost:8080/healthz" >/dev/null 2>&1; then
+      break
+    fi
+  fi
+  if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+    docker logs "$CONTAINER_NAME" >"$LOG_FILE" 2>&1 || true
+    fail "container exited before health check passed"
+  fi
+  sleep 2
+done
+
+docker logs "$CONTAINER_NAME" >"$LOG_FILE" 2>&1 || true
+
+if ! docker exec "$CONTAINER_NAME" curl -sf "http://localhost:8080/healthz" >/dev/null 2>&1; then
+  fail "healthz did not become healthy"
+fi
+
+echo "[validate-local] Inspecting generated config and permissions"
+docker exec "$CONTAINER_NAME" test -f /data/.openclaw/openclaw.json || fail "config file missing"
+CONFIG_MODE="$(docker exec "$CONTAINER_NAME" stat -c '%U:%G %a' /data/.openclaw/openclaw.json 2>/dev/null || true)"
+if [[ "$CONFIG_MODE" != "root:openclaw 640" ]]; then
+  echo "$CONFIG_MODE" > "${ARTIFACT_DIR}/config-mode.txt"
+  fail "config permissions changed"
+fi
+
+docker exec "$CONTAINER_NAME" node -e "
+const fs = require('fs');
+const config = JSON.parse(fs.readFileSync('/data/.openclaw/openclaw.json', 'utf8'));
+if (config.tools?.exec?.security !== 'allowlist') throw new Error('Tier 0 exec security is not allowlist');
+if (!config.tools?.fs?.workspaceOnly) throw new Error('workspaceOnly fs policy is not enabled');
+" || fail "security config assertions failed"
+
+echo "[validate-local] Scanning logs for blocker patterns"
+if grep -Ei 'openclaw\.json\.clobbered|SECRETREF_FAIL|permission denied|EACCES|Cannot find module|Module not found|ready \(0 plugins\)|Gateway exited immediately|Watchdog: gateway process gone|UnhandledPromiseRejection|CIAO PROBING CANCELLED' "$LOG_FILE" \
+  | grep -Eiv "failed to persist plugin auto-enable changes|failed to promote config last-known-good backup" \
+  > "${ARTIFACT_DIR}/blockers.txt"; then
+  fail "blocker log pattern found"
+fi
+
+write_summary "pass" "all local Docker gates passed"
+{
+  echo "# OpenClaw Local Validation: ${VERSION}"
+  echo
+  echo "Status: PASS"
+  echo "Run: ${RUN_ID}"
+  echo "Image: ${IMAGE_TAG}"
+  echo "Health URL: ${HEALTH_URL}"
+  echo
+  echo "Gates:"
+  echo "- npm package exists"
+  echo "- Docker image builds"
+  echo "- installed version matches"
+  echo "- container boots"
+  echo "- /healthz passes"
+  echo "- config exists with root:openclaw 640"
+  echo "- Tier 0 exec allowlist and workspaceOnly assertions pass"
+  echo "- blocker log scan passes"
+} > "$REPORT_MD"
+
+echo "PASS: local Docker validation passed"
+echo "Report: $REPORT_MD"

--- a/scripts/validate-openclaw-railway.sh
+++ b/scripts/validate-openclaw-railway.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: bun run openclaw:validate:railway -- <openclaw-version>"
+  exit 2
+fi
+
+if ! command -v railway >/dev/null 2>&1; then
+  echo "ERROR: railway CLI is required for staging validation"
+  exit 1
+fi
+
+if [[ "${RAILWAY_ENVIRONMENT:-}" != "staging" && "${OPENCLAW_RAILWAY_STAGING_CONFIRMED:-}" != "1" ]]; then
+  cat <<'EOF'
+ERROR: refusing to deploy without explicit staging confirmation.
+
+Set Railway CLI context to the openclaw-railway staging environment, then run:
+
+  RAILWAY_ENVIRONMENT=staging OPENCLAW_RAILWAY_STAGING_CONFIRMED=1 \
+    bun run openclaw:validate:railway -- <version>
+
+This script is intentionally conservative so it does not touch production by
+accident.
+EOF
+  exit 1
+fi
+
+RUN_ID="$(date -u '+%Y%m%dT%H%M%SZ')"
+SAFE_VERSION="$(printf '%s' "$VERSION" | tr -c 'A-Za-z0-9._-' '_')"
+ARTIFACT_DIR=".validation/openclaw/${SAFE_VERSION}/${RUN_ID}-railway"
+TMP_DIR="$(mktemp -d)"
+mkdir -p "$ARTIFACT_DIR"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+echo "[validate-railway] Confirming local candidate passed first"
+LATEST_LOCAL_SUMMARY="$(find ".validation/openclaw/${SAFE_VERSION}" -path '*/summary.json' -not -path '*-railway/*' -print 2>/dev/null | sort | tail -1 || true)"
+if [[ -z "$LATEST_LOCAL_SUMMARY" ]]; then
+  echo "ERROR: no local validation summary found for ${VERSION}"
+  echo "Run: bun run openclaw:validate:local -- ${VERSION}"
+  exit 1
+fi
+node - "$LATEST_LOCAL_SUMMARY" <<'NODE'
+const fs = require('fs');
+const path = process.argv[2];
+const summary = JSON.parse(fs.readFileSync(path, 'utf8'));
+if (summary.status !== 'pass') {
+  console.error(`ERROR: latest local validation is not passing: ${path}`);
+  process.exit(1);
+}
+NODE
+
+echo "[validate-railway] Staging deploy for OpenClaw ${VERSION}"
+echo "[validate-railway] This uses Railway's current project/service/environment context."
+
+rsync -a \
+  --exclude '.git' \
+  --exclude '.validation' \
+  --exclude 'internal' \
+  --exclude 'node_modules' \
+  --exclude '.DS_Store' \
+  ./ "$TMP_DIR"/
+
+node - "$TMP_DIR/Dockerfile" "$VERSION" <<'NODE'
+const fs = require('fs');
+const [path, version] = process.argv.slice(2);
+let text = fs.readFileSync(path, 'utf8');
+text = text.replace(/^ARG OPENCLAW_VERSION=.*$/m, `ARG OPENCLAW_VERSION=${version}`);
+fs.writeFileSync(path, text);
+NODE
+
+RAILWAY_ARGS=(up --detach --environment staging --path-as-root --message "Validate OpenClaw ${VERSION}")
+if [[ -n "${OPENCLAW_RAILWAY_STAGING_SERVICE:-}" ]]; then
+  RAILWAY_ARGS+=(--service "$OPENCLAW_RAILWAY_STAGING_SERVICE")
+fi
+if [[ -n "${OPENCLAW_RAILWAY_PROJECT_ID:-}" ]]; then
+  RAILWAY_ARGS+=(--project "$OPENCLAW_RAILWAY_PROJECT_ID")
+fi
+RAILWAY_ARGS+=("$TMP_DIR")
+
+railway "${RAILWAY_ARGS[@]}" > "${ARTIFACT_DIR}/railway-up.log" 2>&1
+
+echo "[validate-railway] Waiting for health"
+echo "[validate-railway] Waiting for Railway deployment to become active"
+SERVICE_NAME="${OPENCLAW_RAILWAY_STAGING_SERVICE:-openclaw-railway-staging}"
+STATUS_JSON="${ARTIFACT_DIR}/service-status.json"
+ACTIVE="false"
+for _ in $(seq 1 90); do
+  if railway service status --environment staging --service "$SERVICE_NAME" --json > "$STATUS_JSON" 2>"${ARTIFACT_DIR}/service-status.err"; then
+    if node - "$STATUS_JSON" <<'NODE'
+const fs = require('fs');
+const status = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (status.status === 'SUCCESS' && status.stopped === false) process.exit(0);
+process.exit(1);
+NODE
+    then
+      ACTIVE="true"
+      break
+    fi
+  fi
+  sleep 10
+done
+
+if [[ "$ACTIVE" != "true" ]]; then
+  echo "ERROR: staging deployment did not become active"
+  cat "$STATUS_JSON" 2>/dev/null || true
+  exit 1
+fi
+
+HEALTH_URL="${OPENCLAW_STAGING_HEALTH_URL:-}"
+if [[ -z "$HEALTH_URL" ]]; then
+  echo "OPENCLAW_STAGING_HEALTH_URL is not set; external health URL check skipped."
+else
+  for _ in $(seq 1 60); do
+    if curl -sf "$HEALTH_URL/healthz" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 5
+  done
+  curl -sf "$HEALTH_URL/healthz" > "${ARTIFACT_DIR}/healthz.txt" || {
+    echo "ERROR: staging health check failed"
+    exit 1
+  }
+fi
+
+echo "[validate-railway] Capturing Railway logs"
+railway logs --lines 500 > "${ARTIFACT_DIR}/railway.log" 2>&1 || true
+
+if grep -Ei 'openclaw\.json\.clobbered|SECRETREF_FAIL|permission denied|EACCES|Cannot find module|Module not found|ready \(0 plugins\)|Gateway exited immediately|Watchdog: gateway process gone|UnhandledPromiseRejection|CIAO PROBING CANCELLED' "${ARTIFACT_DIR}/railway.log" \
+  | grep -Eiv "failed to persist plugin auto-enable changes|failed to promote config last-known-good backup" \
+  > "${ARTIFACT_DIR}/blockers.txt"; then
+  echo "ERROR: blocker log pattern found"
+  exit 1
+fi
+
+cat > "${ARTIFACT_DIR}/summary.json" <<EOF
+{
+  "target": "railway-staging",
+  "version": "${VERSION}",
+  "status": "pass",
+  "reason": "staging deploy/log gates passed",
+  "runId": "${RUN_ID}",
+  "generatedAt": "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+}
+EOF
+
+cat > "${ARTIFACT_DIR}/report.md" <<EOF
+# OpenClaw Railway Staging Validation: ${VERSION}
+
+Status: PASS
+Run: ${RUN_ID}
+
+Gates:
+- Prior local Docker validation found
+- Railway staging deploy completed
+- Railway deployment became active
+- Health check passed when OPENCLAW_STAGING_HEALTH_URL was provided
+- blocker log scan passed
+
+Manual live-channel smoke test is still required before promotion unless the
+staging service is wired with a dedicated test bot and observer automation.
+EOF
+
+echo "PASS: Railway staging validation passed"
+echo "Report: ${ARTIFACT_DIR}/report.md"

--- a/src/server.js
+++ b/src/server.js
@@ -7,36 +7,37 @@ import http from "node:http";
 import { execSync } from "node:child_process";
 
 const PORT = Number.parseInt(process.env.PORT ?? "8080", 10);
+const PLAIN_HEADERS = {
+  "Content-Type": "text/plain",
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+};
 
 function isGatewayRunning() {
   try {
-    execSync("pidof openclaw-gateway", { stdio: "ignore" });
+    execSync("pgrep -f 'openclaw gateway run|openclaw-gateway'", { stdio: "ignore" });
     return true;
   } catch {
     return false;
   }
 }
 
+function sendPlain(res, status, body) {
+  res.writeHead(status, PLAIN_HEADERS);
+  res.end(body);
+}
+
+// fallow-ignore-next-line complexity
 const server = http.createServer((req, res) => {
   // Health check - verify gateway is actually running
   if (req.url === "/healthz" && req.method === "GET") {
     const gatewayUp = isGatewayRunning();
-    res.writeHead(gatewayUp ? 200 : 503, {
-      "Content-Type": "text/plain",
-      "X-Content-Type-Options": "nosniff",
-      "X-Frame-Options": "DENY",
-    });
-    res.end(gatewayUp ? "OK" : "GATEWAY_DOWN");
+    sendPlain(res, gatewayUp ? 200 : 503, gatewayUp ? "OK" : "GATEWAY_DOWN");
     return;
   }
 
   // Everything else - minimal info (no product name leak)
-  res.writeHead(200, {
-    "Content-Type": "text/plain",
-    "X-Content-Type-Options": "nosniff",
-    "X-Frame-Options": "DENY",
-  });
-  res.end("OK");
+  sendPlain(res, 200, "OK");
 });
 
 server.listen(PORT, "0.0.0.0", () => {


### PR DESCRIPTION
## Summary
- Pin the Docker image to the current latest stable OpenClaw release, `2026.5.3-1`, instead of installing `openclaw@latest` on every redeploy.
- Add local Docker, Railway staging, and promotion scripts so future upstream updates become validated candidates before repo promotion.
- Document the update policy, rollback path, and live-channel smoke-test requirement.

## Changes
- `Dockerfile`: introduces `ARG OPENCLAW_VERSION=2026.5.3-1` and installs that exact package version.
- `.openclaw-version.json`: records the currently pinned runtime version and validation basis.
- `scripts/validate-openclaw-local.sh`: builds a candidate image, boots it locally, checks health/config/perms, and scans logs.
- `scripts/validate-openclaw-railway.sh`: deploys a candidate bundle to Railway staging, waits for an active deployment, checks health when a URL is provided, and scans logs.
- `scripts/promote-openclaw-version.sh`: refuses to bump the pin unless local and Railway staging evidence exist, and treats the npm `latest` dist-tag as stable even when OpenClaw uses a dash hotfix suffix.
- `config/defaults.json`: uses the object-shaped Telegram streaming config required by newer OpenClaw versions.
- `entrypoint.sh` and `src/server.js`: detect the gateway by command shape as well as the older process name.

## Validation
- `bun run openclaw:validate:local -- 2026.5.3-1` passed.
- Railway staging validation for `2026.5.3-1` passed against `openclaw-railway-staging` with public health URL `https://openclaw-railway-staging-staging.up.railway.app`.
- `node --check src/server.js && node --check src/build-config.js && bash -n scripts/validate-openclaw-local.sh scripts/validate-openclaw-railway.sh scripts/promote-openclaw-version.sh entrypoint.sh config-watcher.sh tests/run-security-tests.sh` passed.
- `fallow audit --format json --quiet` passed.
- Pre-push Fallow gate passed.

## Notes
- Beta releases are not considered for the template pin.
- `2026.5.3-1` is the current npm `latest` stable release.
- Staging infrastructure validation passed. Dedicated live channel credentials are still needed for a full real-message smoke test before relying on staging for future autonomous promotions.
