### PR TITLE
chore: promote OpenClaw to 2026.5.7

### DIFF
--- a/.openclaw-version.json
+++ b/.openclaw-version.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026.5.5",
+  "version": "2026.5.7",
   "channel": "stable",
-  "promotedAt": "2026-05-06",
+  "promotedAt": "2026-05-10",
   "validatedBy": "local-docker+railway-staging",
-  "notes": "Promoted after local Docker and Railway staging validation. Previous version: 2026.5.3-1."
+  "notes": "Promoted after local Docker and Railway staging validation. Previous version: 2026.5.5."
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM node:22-bookworm
 
-ARG OPENCLAW_VERSION=2026.5.5
+ARG OPENCLAW_VERSION=2026.5.7
 
 # Install minimal runtime dependencies
 RUN apt-get update \


### PR DESCRIPTION
## Summary
- Promotes the pinned OpenClaw runtime from `2026.5.5` to `2026.5.7`.
- Updates the Docker build ARG and `.openclaw-version.json` promotion metadata.
- Uses the release sentinel evidence from local Docker and Railway staging validation.

## Validation
- Local Docker validation: PASS (`.validation/openclaw/2026.5.7/20260510T054935Z/report.md`)
- Railway staging validation: PASS (`.validation/openclaw/2026.5.7/20260510T055034Z-railway/report.md`)
- Sentinel verdict: PROMOTE (`.validation/openclaw/2026.5.7/20260510T054933Z-sentinel/evaluation.md`)
- Pre-push Fallow gate: skipped because no JS/TS/Svelte files changed

## Notes
- Current upstream stable: `openclaw@2026.5.7` and `@openclaw/discord@2026.5.7`.
- Manual live-channel smoke test is still required before full production/template rollout unless a dedicated staging bot/observer automation is available.
- This PR does not publish the Railway template, deploy production, or send Discord messages.