### PR TITLE
chore(openclaw): promote runtime to 2026.5.22

### DIFF
--- a/.openclaw-version.json
+++ b/.openclaw-version.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026.5.18",
+  "version": "2026.5.22",
   "channel": "stable",
-  "promotedAt": "2026-05-20",
+  "promotedAt": "2026-05-24",
   "validatedBy": "local-docker+railway-staging",
-  "notes": "Promoted after local Docker and Railway staging validation. Previous version: 2026.5.7."
+  "notes": "Promoted after local Docker and Railway staging validation. Previous version: 2026.5.18."
 }

--- a/.openclaw-version.json
+++ b/.openclaw-version.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026.5.7",
+  "version": "2026.5.18",
   "channel": "stable",
-  "promotedAt": "2026-05-10",
+  "promotedAt": "2026-05-20",
   "validatedBy": "local-docker+railway-staging",
-  "notes": "Promoted after local Docker and Railway staging validation. Previous version: 2026.5.5."
+  "notes": "Promoted after local Docker and Railway staging validation. Previous version: 2026.5.7."
 }

--- a/.openclaw-version.json
+++ b/.openclaw-version.json
@@ -3,5 +3,5 @@
   "channel": "stable",
   "promotedAt": "2026-05-24",
   "validatedBy": "local-docker+railway-staging",
-  "notes": "Promoted after local Docker and Railway staging validation. Previous version: 2026.5.18."
+  "notes": "Promoted after local Docker and Railway staging validation. Previous version: 2026.5.7."
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM node:22-bookworm
 
-ARG OPENCLAW_VERSION=2026.5.7
+ARG OPENCLAW_VERSION=2026.5.18
 
 # Install minimal runtime dependencies
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM node:22-bookworm
 
-ARG OPENCLAW_VERSION=2026.5.18
+ARG OPENCLAW_VERSION=2026.5.22
 
 # Install minimal runtime dependencies
 RUN apt-get update \


### PR DESCRIPTION
## Summary
- Promotes the pinned OpenClaw runtime from `2026.5.7` through `2026.5.18` to current stable `2026.5.22`.
- Updates `.openclaw-version.json` promotion metadata and the Dockerfile `OPENCLAW_VERSION` arg.
- Keeps this as a follow-up commit on the existing draft promotion PR; no history rewrite or force push.

## Validation
- Latest stable upstream check on 2026-05-24: `openclaw` `2026.5.22`, `@openclaw/discord` `2026.5.22`; prereleases treated as informational only.
- Sentinel verdict: `PROMOTE` — `.validation/openclaw/2026.5.22/20260524T123624Z-sentinel/evaluation.md`.
- Railway staging validation: `PASS` — `.validation/openclaw/2026.5.22/20260524T124115Z-railway/report.md`.
- Local validation before promotion: `PASS` — `.validation/openclaw/2026.5.22/20260524T123625Z/report.md`.
- Local validation after promotion: `PASS` — `.validation/openclaw/2026.5.22/20260524T124540Z/report.md`.
- `2026.5.20` was rechecked and blocked locally with `healthz did not become healthy`, so it was skipped in favor of current stable `2026.5.22`.

## Human approvals still required
- Mark ready/merge to `main`.
- Railway template publishing.
- Production deployment/monitoring.
- Real Discord smoke messages, if desired.

## Rollback
- Revert this PR to restore the previous mainline pin `2026.5.7`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Promoted version `2026.5.22` to the stable release channel

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mattslayga/openclaw-railway/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->